### PR TITLE
 Config-driven skills, lexicon-constrained TF-IDF, DOCX support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,19 +1,89 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+
+from rapidfuzz import fuzz, process
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-import fitz
-import re 
+import fitz  # PyMuPDF
+import re, io, json, os
+from pathlib import Path
+import docx
+from docx.opc.exceptions import OpcError
+from typing import Set, Dict, List
 
+# --------------------------------------------------------------------------------------
+# App setup
+# --------------------------------------------------------------------------------------
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
-MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file for v1
+# Enable CORS for local React dev (adjust as needed)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
+# --------------------------------------------------------------------------------------
+# Config / constants
+# --------------------------------------------------------------------------------------
+MAX_BYTES = 5 * 1024 * 1024   # 5 MB per file
+FUZZ_THRESHOLD = 85           # 80–90 typical
+
+CONFIG_PATH = Path("skills_config.json")
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "change-me")  # set env var in prod
+
+# Filled by loader at startup
+STOPWORDS: Set[str] = set()
+SKILL_LEXICON: Set[str] = set()         # base skill tokens
+SKILL_ALIASES: Dict[str, List[str]] = {}  # base -> [alias, ...]
+
+# --------------------------------------------------------------------------------------
+# Regex (precompiled)
+# --------------------------------------------------------------------------------------
+EMAIL_RE   = re.compile(r"\S+@\S+")
+PHONE_RE   = re.compile(r"\b(?:\+?\d[\d\-\s]{7,}\d)\b")
+URL_RE     = re.compile(r"https?://\S+|www\.\S+")
+CLEAN_RE   = re.compile(r"[^a-z0-9\+\#\.\-\/\s]")
+SPACE_RE   = re.compile(r"\s+")
+TOKEN_RE   = re.compile(r"[a-z0-9\+\#\.\-\/]{2,}")
+
+# --------------------------------------------------------------------------------------
+# Config loader
+# --------------------------------------------------------------------------------------
+def load_skills_config(path: Path = CONFIG_PATH):
+    global STOPWORDS, SKILL_LEXICON, SKILL_ALIASES
+    if not path.exists():
+        raise RuntimeError(f"Config not found: {path.resolve()}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    STOPWORDS = set((w.lower().strip() for w in data.get("stopwords", [])))
+
+    SKILL_LEXICON = set()
+    SKILL_ALIASES = {}
+    for item in data.get("skills", []):
+        base = item["name"].lower().strip()
+        SKILL_LEXICON.add(base)
+        alts = [a.lower().strip() for a in item.get("aliases", [])]
+        SKILL_ALIASES[base] = alts
+
+    # Optional: include alias tokens in lexicon to simplify filtering
+    for _, alts in SKILL_ALIASES.items():
+        for a in alts:
+            SKILL_LEXICON.add(a)
+
+# Load once at startup
+load_skills_config()
+
+# --------------------------------------------------------------------------------------
+# Helpers: I/O and extraction
+# --------------------------------------------------------------------------------------
 async def _read_bytes(f: UploadFile) -> bytes:
-    # Reset pointer, read, enforce size, and reset again for safety
     await f.seek(0)
     data = await f.read()
     await f.seek(0)
@@ -25,24 +95,139 @@ async def extract_text(file: UploadFile) -> str:
     name = (file.filename or "").lower()
     data = await _read_bytes(file)
 
+    # .txt
     if name.endswith(".txt"):
-        # Decode text files defensively
         return data.decode("utf-8", errors="ignore")
 
+    # .pdf
     if name.endswith(".pdf"):
-        # Iterate all pages. Your original code returned after page 1.
-        text_chunks = []
         try:
             with fitz.open(stream=data, filetype="pdf") as doc:
-                for page in doc:
-                    text_chunks.append(page.get_text())
-        except fitz.FileDataError:
-            raise HTTPException(status_code=400, detail="Invalid PDF")
-        return "\n".join(text_chunks)
+                if doc.is_encrypted:
+                    try:
+                        doc.authenticate("")
+                    except Exception:
+                        raise HTTPException(status_code=400, detail="Encrypted PDF not supported")
+                text_chunks = [page.get_text("text") for page in doc]
+        except (fitz.FileDataError, RuntimeError):
+            raise HTTPException(status_code=400, detail="Invalid or unreadable PDF")
+        return "\n".join(t for t in text_chunks if t and t.strip())
 
-    # Add .docx later; keep v1 narrow to reduce moving parts
-    raise HTTPException(status_code=415, detail="Unsupported file type. Use .txt or .pdf for now.")
+    # .docx
+    if name.endswith(".docx"):
+        try:
+            d = docx.Document(io.BytesIO(data))
+        except OpcError:
+            raise HTTPException(status_code=400, detail="Invalid DOCX file")
 
+        parts: List[str] = []
+        # paragraphs
+        for p in d.paragraphs:
+            txt = (p.text or "").strip()
+            if txt:
+                parts.append(txt)
+        # tables
+        for tbl in d.tables:
+            for row in tbl.rows:
+                cells = [c.text.strip() for c in row.cells if c.text and c.text.strip()]
+                if cells:
+                    parts.append(" | ".join(cells))
+        return "\n".join(parts)
+
+    # unsupported
+    raise HTTPException(status_code=415, detail="Unsupported file type. Use .txt, .pdf, or .docx.")
+
+# --------------------------------------------------------------------------------------
+# Text processing
+# --------------------------------------------------------------------------------------
+def normalize(s: str) -> str:
+    s = s.lower()
+    s = EMAIL_RE.sub(" ", s)
+    s = PHONE_RE.sub(" ", s)
+    s = URL_RE.sub(" ", s)
+    s = CLEAN_RE.sub(" ", s)
+    s = SPACE_RE.sub(" ", s).strip()
+    return s
+
+def tokenize_words(s: str) -> List[str]:
+    return TOKEN_RE.findall(s)
+
+def extract_candidate_keywords(jd_text: str) -> List[str]:
+    # JD tokens filtered to skill lexicon or known base skills
+    tokens = [t for t in tokenize_words(jd_text) if t not in STOPWORDS]
+    tokens = [t for t in tokens if (t in SKILL_LEXICON) or (t in SKILL_ALIASES)]
+    freq: Dict[str, int] = {}
+    for t in tokens:
+        freq[t] = freq.get(t, 0) + 1
+    top = sorted(freq.items(), key=lambda x: x[1], reverse=True)[:50]
+    return [w for w, _ in top]
+
+# --------------------------------------------------------------------------------------
+# Matching and scoring
+# --------------------------------------------------------------------------------------
+def fuzzy_match_term(term: str, resume_tokens: List[str]) -> bool:
+    # exact first
+    if term in resume_tokens:
+        return True
+    # aliases and fuzzy
+    candidates = [term] + SKILL_ALIASES.get(term, [])
+    for cand in candidates:
+        m = process.extractOne(cand, resume_tokens, scorer=fuzz.token_set_ratio)
+        if m and m[1] >= FUZZ_THRESHOLD:
+            return True
+    return False
+
+def _lexicon_vocabulary() -> Dict[str, int]:
+    # Build a fixed vocabulary from skills (keep tokens that match TOKEN_RE)
+    vocab_terms = {t for t in SKILL_LEXICON if TOKEN_RE.fullmatch(t)}
+    # Stable ordering
+    return {term: i for i, term in enumerate(sorted(vocab_terms))}
+
+def tfidf_cosine_lexicon(resume_text: str, jd_text: str) -> float:
+    vocab = _lexicon_vocabulary()
+    if not vocab:
+        return 0.0
+    try:
+        vectorizer = TfidfVectorizer(
+            ngram_range=(1, 2),
+            lowercase=False,  # already normalized
+            token_pattern=r"[a-z0-9\+\#\.\-\/]{2,}",
+            stop_words=None,
+            vocabulary=vocab,
+            sublinear_tf=True,
+        )
+        X = vectorizer.fit_transform([jd_text, resume_text])
+        cos = cosine_similarity(X[0], X[1])[0][0]
+        return float(round(cos, 3))
+    except ValueError:
+        return 0.0
+
+def keyword_match(resume_text: str, jd_text: str) -> Dict:
+    jd_keys = extract_candidate_keywords(jd_text)
+    resume_tokens_list = list(set(tokenize_words(resume_text)))
+
+    matched, missing = [], []
+    for k in jd_keys:
+        if fuzzy_match_term(k, resume_tokens_list):
+            matched.append(k)
+        else:
+            missing.append(k)
+
+    coverage = round(len(matched) / max(1, len(jd_keys)), 3)
+    cosine_similarity_score = tfidf_cosine_lexicon(resume_text, jd_text)
+    overall_score = round(0.75 * cosine_similarity_score + 0.25 * coverage, 3)
+
+    return {
+        "overall_score": overall_score,
+        "cosine_similarity": cosine_similarity_score,
+        "coverage": coverage,
+        "matched": matched[:50],
+        "missing_sample": missing[:20],
+    }
+
+# --------------------------------------------------------------------------------------
+# Endpoints
+# --------------------------------------------------------------------------------------
 @app.post("/analyze")
 async def analyze_files(
     resume: UploadFile = File(...),
@@ -50,74 +235,12 @@ async def analyze_files(
 ):
     resume_text = await extract_text(resume)
     jd_text = await extract_text(job_description)
-
     return {
         "resume_preview": resume_text[:400],
         "jd_preview": jd_text[:400],
         "resume_chars": len(resume_text),
         "jd_chars": len(jd_text),
     }
-
-STOPWORDS = {
-    "and","or","the","a","an","to","of","in","for","with","on","at","by","from",
-    "is","are","be","as","this","that","it","you","we","they","our","their"
-}
-
-# --- normalization/tokenization ---
-def normalize(s: str) -> str:
-    s = s.lower()
-    s = re.sub(r"\S+@\S+", " ", s)                            # emails
-    s = re.sub(r"\b(?:\+?\d[\d\-\s]{7,}\d)\b", " ", s)        # phones
-    s = re.sub(r"https?://\S+|www\.\S+", " ", s)              # urls
-    s = re.sub(r"[^a-z0-9\+\#\.\-\/\s]", " ", s)              # keep + # . - /
-    s = re.sub(r"\s+", " ", s).strip()
-    return s
-
-def tokenize_words(s: str):
-    return re.findall(r"[a-z0-9\+\#\.\-\/]{2,}", s)
-
-def extract_candidate_keywords(jd_text: str) -> list[str]:
-    tokens = [t for t in tokenize_words(jd_text) if t not in STOPWORDS]
-    freq = {}
-    for t in tokens:
-        freq[t] = freq.get(t, 0) + 1
-    top = sorted(freq.items(), key=lambda x: x[1], reverse=True)[:50]
-    return [w for w,_ in top]
-
-def keyword_match(resume_text: str, jd_text: str):
-    jd_keys = extract_candidate_keywords(jd_text)
-    resume_tokens = set(tokenize_words(resume_text))
-    matched = [k for k in jd_keys if k in resume_tokens]
-    coverage = round(len(matched) / max(1, len(jd_keys)), 3)
-    # Call the tfidf_cosine function to get the semantic score
-    cosine_similarity_score = tfidf_cosine(resume_text, jd_text)
-    
-    # simple composite: weight semantic higher than coverage
-    overall_score = round(0.65 * cosine_similarity_score + 0.35 * coverage, 3)
-
-    return {
-        "overall_score": overall_score,
-        "cosine_similarity": cosine_similarity_score,
-        "coverage": coverage,
-        "matched": matched,
-        "missing_sample": [k for k in jd_keys if k not in resume_tokens][:20]
-    }
-
-# --- tfidf with guard and matching token pattern ---
-def tfidf_cosine(resume_text: str, jd_text: str) -> float:
-    try:
-        vectorizer = TfidfVectorizer(
-            ngram_range=(1, 2),
-            lowercase=False,                               # already normalized
-            token_pattern=r"[a-z0-9\+\#\.\-\/]{2,}",
-            stop_words=None                                # optional: 'english'
-        )
-        tfidf_matrix = vectorizer.fit_transform([jd_text, resume_text])
-        cos = cosine_similarity(tfidf_matrix[0], tfidf_matrix[1])[0][0]
-        return float(round(cos, 3))
-    except ValueError:
-        # e.g., empty vocabulary after normalization
-        return 0.0
 
 @app.post("/score")
 async def score(
@@ -126,13 +249,21 @@ async def score(
 ):
     resume_raw = await extract_text(resume)
     jd_raw = await extract_text(job_description)
-
-    # normalize for both methods
     resume_text = normalize(resume_raw)
     jd_text = normalize(jd_raw)
+    return keyword_match(resume_text, jd_text)
 
-
-    score_data = keyword_match(resume_text, jd_text)
-    
-    # Return the entire dictionary of scores and data.
-    return score_data
+@app.post("/admin/reload-skills")
+def reload_skills(x_admin_token: str = Header(None)):
+    if x_admin_token != ADMIN_TOKEN:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    try:
+        load_skills_config()
+        return {
+            "status": "ok",
+            "skills_in_lexicon": len(SKILL_LEXICON),
+            "bases_with_aliases": len(SKILL_ALIASES),
+            "stopwords": len(STOPWORDS),
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Reload failed: {e}")

--- a/skills_config.json
+++ b/skills_config.json
@@ -1,0 +1,48 @@
+{
+  "stopwords": [
+    "and","or","the","a","an","to","of","in","for","with","on","at","by","from",
+    "is","are","be","as","this","that","it","you","we","they","our","their"
+  ],
+  "skills": [
+    { "name": "python",        "aliases": ["py"] },
+    { "name": "javascript",    "aliases": ["js","java script"] },
+    { "name": "typescript",    "aliases": ["ts","type script"] },
+    { "name": "java",          "aliases": [] },
+    { "name": "c++",           "aliases": ["cpp"] },
+    { "name": "c#",            "aliases": ["c sharp","c-sharp"] },
+    { "name": "go",            "aliases": ["golang"] },
+    { "name": "sql",           "aliases": [] },
+
+    { "name": "react",         "aliases": ["reactjs","react.js","react js"] },
+    { "name": "angular",       "aliases": ["angularjs","angular.js"] },
+    { "name": "vue",           "aliases": ["vuejs","vue.js","vue js"] },
+    { "name": "fastapi",       "aliases": ["fast api"] },
+    { "name": "django",        "aliases": [] },
+    { "name": "flask",         "aliases": [] },
+    { "name": "express",       "aliases": ["expressjs","express.js"] },
+    { "name": "node.js",       "aliases": ["node","nodejs"] },
+
+    { "name": "tensorflow",    "aliases": ["tf","tensor flow"] },
+    { "name": "pytorch",       "aliases": ["torch"] },
+    { "name": "scikit-learn",  "aliases": ["sklearn","scikit learn"] },
+    { "name": "keras",         "aliases": [] },
+    { "name": "pandas",        "aliases": [] },
+    { "name": "numpy",         "aliases": [] },
+    { "name": "opencv",        "aliases": ["open cv"] },
+
+    { "name": "postgresql",    "aliases": ["postgres","postgre","psql"] },
+    { "name": "mysql",         "aliases": ["my sql"] },
+    { "name": "mongodb",       "aliases": ["mongo","mongo db"] },
+    { "name": "sqlite",        "aliases": ["sqlite3"] },
+    { "name": "redis",         "aliases": [] },
+
+    { "name": "aws",           "aliases": ["amazon web services","ec2","s3","iam","lambda"] },
+    { "name": "gcp",           "aliases": ["google cloud platform","google cloud"] },
+    { "name": "azure",         "aliases": ["microsoft azure","azure cloud"] },
+    { "name": "docker",        "aliases": [] },
+    { "name": "kubernetes",    "aliases": ["k8s"] },
+    { "name": "ci/cd",         "aliases": ["continuous integration","continuous deployment"] },
+    { "name": "git",           "aliases": ["git version control"] },
+    { "name": "linux",         "aliases": ["unix","gnu linux"] }
+  ]
+}


### PR DESCRIPTION
feat: config-driven skills + lexicon TF-IDF; DOCX support; CORS; admin reload
Add skills_config.json; load at startup; /admin/reload-skills with header token.
Constrain TF-IDF vocabulary to skills lexicon for cleaner cosine similarity. Replace hard-coded stopwords/aliases with JSON config; add RapidFuzz fuzzy matching. Improve text extraction: DOCX paragraphs+tables, hardened PDF; size limits and errors. Align normalization/tokenization with precompiled regex; stable JSON from score. Enable CORS for React (localhost); add requirements.txt and .gitignore.