### PR TITLE
Add CI workflow for tests and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest
+
+  frontend-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: smart-resume-ui/package-lock.json
+      - name: Install dependencies
+        working-directory: smart-resume-ui
+        run: npm ci
+      - name: Run lint
+        working-directory: smart-resume-ui
+        run: npm run lint


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running backend pytest and frontend lint
- cache pip and npm dependencies to speed up CI

## Testing
- `pytest -q`
- `npm run lint`
